### PR TITLE
Fix invincible monika and interaction error

### DIFF
--- a/definitions.rpy
+++ b/definitions.rpy
@@ -1938,7 +1938,7 @@ init python:
     # Re-set the callback to the ADVCharacter replaced by the translation.
     def set_character_callback():
         s.display_args["callback"] = speaker("sayori")
-        m.display_args["callback"] = speaker("monika")
+        m.display_args["callback"] = speaker("monika") if persistent.playthrough <= 2 else slow_nodismiss
         n.display_args["callback"] = speaker("natsuki")
         y.display_args["callback"] = speaker("yuri")
         ny.display_args["callback"] = speaker("nat&yuri")

--- a/script-ch30.rpy
+++ b/script-ch30.rpy
@@ -140,8 +140,8 @@ init python:
     dismiss_keys = config.keymap['dismiss']
 
     def slow_nodismiss(event, interact=True, **kwargs):
-        if not persistent.monika_kill:
-            m.display_args["callback"] = speaker("monika")
+        speaker_callback("monika", event, interact=interact, **kwargs)
+        if event != "slow_done" and not persistent.monika_kill:
             try:
                 renpy.file("../characters/monika.chr")
             except:


### PR DESCRIPTION
- Act3 で monika.chr を削除しても、再起動するか callback が上書きされるまでお構いなしに会話を続けてしまうバグを修正
- proudust/ddlc-jp-patch#9 を BlinkyFlappers 側でも対策
